### PR TITLE
Orte für Geschäftsführende Versammlungen

### DIFF
--- a/_data/calendar.yml
+++ b/_data/calendar.yml
@@ -585,27 +585,27 @@
 - title: Geschäftsführende Versammlung
   datum: "2023-06-28"
   uhrzeit: "20.00h"
-  ort: "tbd"
+  ort: "Raum Flex Office 2, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
 
 - title: Geschäftsführende Versammlung
   datum: "2023-07-12"
   uhrzeit: "20.00h"
-  ort: "tbd"
+  ort: "Raum Flex Office 2, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
 
 - title: Geschäftsführende Versammlung
   datum: "2023-07-26"
   uhrzeit: "20.00h"
-  ort: "tbd"
+  ort: "Raum Lovelace, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
 
 - title: Geschäftsführende Versammlung
   datum: "2023-08-09"
   uhrzeit: "20.00h"
-  ort: "tbd"
+  ort: "Raum Lovelace, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
 
 - title: Geschäftsführende Versammlung
-  datum: "2023-08-25"
+  datum: "2023-08-23"
   uhrzeit: "20.00h"
-  ort: "tbd"
+  ort: "Raum Lovelace, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
 
 - title: TechTurbo 2023
   datum: "2023-11-30"


### PR DESCRIPTION
Räume sind allesamt gebucht.

Der Termin 25.8. war ein Freitag, ist jetzt zum Mittwoch den 23.8. korrigiert.