### PR TITLE
Kalender: Geschäftsführende Versammlung am 07.02. und 21.02.2024

### DIFF
--- a/_data/calendar.yml
+++ b/_data/calendar.yml
@@ -731,3 +731,13 @@
   datum: "2024-01-24"
   uhrzeit: "20.00h"
   ort: "Raum Flex Office 1, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
+
+
+- title: Geschäftsführende Versammlung
+  datum: "2024-02-07"
+  uhrzeit: "20.00h"
+  ort: "Flex Office 1, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"
+- title: Geschäftsführende Versammlung
+  datum: "2024-02-21"
+  uhrzeit: "20.00h"
+  ort: "Flex Office 1, 3.OG, Collective Incubator, Jülicher Str. 209d, 52070 Aachen"


### PR DESCRIPTION
Erst mal die nächsten beiden Termine für die Geschäftsführenden Versammlung. Weiter Termine folgen nach Besprechung mit de Rest des Vorstandes.