### PR TITLE
[tech] Calendar entries across monthly borders

### DIFF
--- a/Dockerfile.pfusch
+++ b/Dockerfile.pfusch
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+LABEL maintainer="Raphael Lehmann <raphael+docker@rleh.de>"
+LABEL description="Jekyll Pfusch image"
+
+WORKDIR /work
+
+ADD Gemfile /work
+
+ENV LANG="en_US.UTF-8"
+ENV TZ=Europe/Berlin
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get upgrade -y -qq && \
+    apt-get install -y -qq \
+      ruby-full \
+      rubygems \
+      libffi-dev \
+      build-essential && \
+    apt-get clean -qq
+RUN gem install jekyll bundler
+RUN bundle install

--- a/_data/calendar.yml
+++ b/_data/calendar.yml
@@ -635,12 +635,7 @@
 - title: TechTurbo 2023
   datum: "2023-11-30"
   uhrzeit: "16.00h"
-  dauer: 8
-  ort: "Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden"
-- title: TechTurbo 2023
-  datum: "2023-12-01"
-  uhrzeit: "00.00h"
-  dauer: 62
+  dauer: 70
   ort: "Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden"
 
 - title: Frühstück
@@ -825,12 +820,7 @@
 - title: TechTurbo 2024
   datum: "2024-11-28"
   uhrzeit: "18.00h"
-  dauer: 54
-  ort: "Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden"
-- title: TechTurbo 2024
-  datum: "2024-12-01"
-  uhrzeit: "00.00h"
-  dauer: 14
+  dauer: 68
   ort: "Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden"
 
 - title: Geschäftsführende Versammlung

--- a/static/calendar.ics
+++ b/static/calendar.ics
@@ -24,22 +24,18 @@ RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
 END:STANDARD
 END:VTIMEZONE
 {% for termin in site.data.calendar -%}
-{% assign start_uhrzeit = termin.uhrzeit | remove: "h" | remove: "." | append: "00" -%}
-{% assign start = termin.datum | remove: "-" | append: "T" | append: start_uhrzeit -%}
+{% assign start_date = termin.datum | append: " " | append: termin.uhrzeit | remove: "h" | replace: ".", ":" | date: '%s' -%}
 {% if termin.dauer -%}
-{%  assign dauer = termin.dauer | times: 100 -%}
+{%  assign dauer_seconds = termin.dauer | times: 3600 -%}
 {% else -%}
-{%  assign dauer = 100 -%}
+{%  assign dauer_seconds = 3600 -%}
 {% endif -%}
-{% assign end_uhrzeit = termin.uhrzeit | remove: "h" | remove: "." | plus: dauer -%}
-{% assign dauer_tage = end_uhrzeit | divided_by: 2400 -%}
-{% assign end_uhrzeit = end_uhrzeit | modulo: 2400 -%}
-{% assign end = termin.datum | remove: "-" | plus: dauer_tage | append: "T" | append: end_uhrzeit | append: "00" -%}
+{% assign end = start_date | plus: dauer_seconds | round | date: '%Y%m%dT%H%M%S' -%}
 BEGIN:VEVENT
-UID:meeting+{{ start }}@techaachen.de
+UID:meeting+{{ start_date | date: '%Y%m%dT%H%M%S' }}@techaachen.de
 SUMMARY:TechAachen - {{ termin.title }}
 LOCATION:{{ termin.ort }}
-DTSTART;TZID=Europe/Berlin:{{ start }}
+DTSTART;TZID=Europe/Berlin:{{ start_date | date: '%Y%m%dT%H%M%S' }}
 DTEND;TZID=Europe/Berlin:{{ end }}
 DTSTAMP:{{ site.time | date: '%Y%m%dT%H%M%SZ' }}
 END:VEVENT

--- a/static/calendar.ics
+++ b/static/calendar.ics
@@ -23,8 +23,17 @@ DTSTART:19701025T030000
 RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
 END:STANDARD
 END:VTIMEZONE
+{% assign uids = "" -%}
 {% for termin in site.data.calendar -%}
 {% assign start_date = termin.datum | append: " " | append: termin.uhrzeit | remove: "h" | replace: ".", ":" | date: '%s' -%}
+{% assign start = start_date | date: '%Y%m%dT%H%M%S' -%}
+{% if uids contains start -%}
+{%  assign uidaddition = termin.ort | url_encode -%}
+{%  assign uid = start | append: uidaddition -%}
+{% else -%}
+{%  assign uid = start -%}
+{% endif -%}
+{% assign uids = uids | append: "," | append: uid -%}
 {% if termin.dauer -%}
 {%  assign dauer_seconds = termin.dauer | times: 3600 -%}
 {% else -%}
@@ -32,10 +41,10 @@ END:VTIMEZONE
 {% endif -%}
 {% assign end = start_date | plus: dauer_seconds | round | date: '%Y%m%dT%H%M%S' -%}
 BEGIN:VEVENT
-UID:meeting+{{ start_date | date: '%Y%m%dT%H%M%S' }}@techaachen.de
+UID:meeting+{{ uid }}@techaachen.de
 SUMMARY:TechAachen - {{ termin.title }}
 LOCATION:{{ termin.ort }}
-DTSTART;TZID=Europe/Berlin:{{ start_date | date: '%Y%m%dT%H%M%S' }}
+DTSTART;TZID=Europe/Berlin:{{ start }}
 DTEND;TZID=Europe/Berlin:{{ end }}
 DTSTAMP:{{ site.time | date: '%Y%m%dT%H%M%SZ' }}
 END:VEVENT


### PR DESCRIPTION
Finally 🥳 

---

Seems to work, below are old.ics and new.ics compared using `git diff --no-index -I "DTSTAMP" old.ics.txt new.ics.txt`.

The changes in the generated ICS file are:
- `DTSTAMP` fields (obviously ... they contain the current time)
- some previously broken end times
- TechTurbo entries, because of 016a5f0

<details>
<summary>
Click to view diff
</summary>

[new.ics.txt](https://github.com/TechAachen/Webseite-Jekyll/files/15472950/new.ics.txt)
[old.ics.txt](https://github.com/TechAachen/Webseite-Jekyll/files/15472951/old.ics.txt)

```diff
diff --git a/old.ics b/new.ics
index eb65f61..966cc15 100644
--- a/old.ics
+++ b/new.ics
@@ -905,8 +905,8 @@ UID:meeting+20221024T083000@techaachen.de
 SUMMARY:TechAachen - Women@TechAachen - Design Thinking Workshop mit female@FIR
 LOCATION:Details bitte bei Women@TechAachen erfragen; Anmeldung erforderlich
 DTSTART;TZID=Europe/Berlin:20221024T083000
-DTEND;TZID=Europe/Berlin:20221024.7T1680.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20221024T170000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20221026T200000@techaachen.de
@@ -1145,24 +1145,16 @@ UID:meeting+20231130T160000@techaachen.de
 SUMMARY:TechAachen - TechTurbo 2023
 LOCATION:Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231130T160000
-DTEND;TZID=Europe/Berlin:20231131T000
-DTSTAMP:20240528T000622Z
-END:VEVENT
-BEGIN:VEVENT
-UID:meeting+20231201T000000@techaachen.de
-SUMMARY:TechAachen - TechTurbo 2023
-LOCATION:Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
-DTSTART;TZID=Europe/Berlin:20231201T000000
 DTEND;TZID=Europe/Berlin:20231203T140000
-DTSTAMP:20240528T000622Z
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T083000@techaachen.de
 SUMMARY:TechAachen - Frühstück
 LOCATION:Einstein, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T083000
-DTEND;TZID=Europe/Berlin:20231202.408333335T980.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T100000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T093000@techaachen.de
@@ -1177,16 +1169,16 @@ UID:meeting+20231202T100000@techaachen.de
 SUMMARY:TechAachen - Altium Designer Workshop
 LOCATION:Raum Yousafzai, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T100000
-DTEND;TZID=Europe/Berlin:20231202.520833332T1250.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T123000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T123000@techaachen.de
 SUMMARY:TechAachen - Gruppenfoto
 LOCATION:Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T123000
-DTEND;TZID=Europe/Berlin:20231202.533333335T1280.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T130000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T130000@techaachen.de
@@ -1201,8 +1193,8 @@ UID:meeting+20231202T153000@techaachen.de
 SUMMARY:TechAachen - FreeRTOS Workshop
 LOCATION:Curie, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T153000
-DTEND;TZID=Europe/Berlin:20231202.7T1680.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T170000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T153000@techaachen.de
@@ -1217,16 +1209,16 @@ UID:meeting+20231202T173000@techaachen.de
 SUMMARY:TechAachen - KiCAD Workshop
 LOCATION:Curie, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T173000
-DTEND;TZID=Europe/Berlin:20231202.783333335T1880.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T190000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T173000@techaachen.de
 SUMMARY:TechAachen - Indesign Workshop
 LOCATION:Yousafzai, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T173000
-DTEND;TZID=Europe/Berlin:20231202.783333335T1880.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T190000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T210000@techaachen.de
@@ -1241,8 +1233,8 @@ UID:meeting+20231202T083000@techaachen.de
 SUMMARY:TechAachen - Frühstück
 LOCATION:Einstein, Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20231202T083000
-DTEND;TZID=Europe/Berlin:20231202.408333335T980.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231202T100000
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231202T130000@techaachen.de
@@ -1265,8 +1257,8 @@ UID:meeting+20231213T200000@techaachen.de
 SUMMARY:TechAachen - Geschäftsführende Versammlung
 LOCATION:Raum 2090|U203 (FT103), Melatener Str. 23-25
 DTSTART;TZID=Europe/Berlin:20231213T200000
-DTEND;TZID=Europe/Berlin:20231213.84375T2025.000
-DTSTAMP:20240528T000622Z
+DTEND;TZID=Europe/Berlin:20231213T201500
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20231213T201500@techaachen.de
@@ -1473,16 +1465,8 @@ UID:meeting+20241128T180000@techaachen.de
 SUMMARY:TechAachen - TechTurbo 2024
 LOCATION:Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
 DTSTART;TZID=Europe/Berlin:20241128T180000
-DTEND;TZID=Europe/Berlin:20241131T000
-DTSTAMP:20240528T000622Z
-END:VEVENT
-BEGIN:VEVENT
-UID:meeting+20241201T000000@techaachen.de
-SUMMARY:TechAachen - TechTurbo 2024
-LOCATION:Gruppenunterkunft Auszeit Eifel, Auf der Batterie 9, Schleiden
-DTSTART;TZID=Europe/Berlin:20241201T000000
 DTEND;TZID=Europe/Berlin:20241201T140000
-DTSTAMP:20240528T000622Z
+DTSTAMP:20240528T160441Z
 END:VEVENT
 BEGIN:VEVENT
 UID:meeting+20241211T200000@techaachen.de
```

</details>
